### PR TITLE
Update DlsDirectGrantX509Authenticator.java

### DIFF
--- a/src/main/java/mil/army/usace/dls/keycloak/authenticator/DlsDirectGrantX509Authenticator.java
+++ b/src/main/java/mil/army/usace/dls/keycloak/authenticator/DlsDirectGrantX509Authenticator.java
@@ -61,6 +61,10 @@ public class DlsDirectGrantX509Authenticator implements Authenticator {
                 } else {
                     log.info(String.format("DLS SPI LOG -> Existing user detected with %s '%s' .", UserModel.USERNAME,
                             existingUser.getUsername()));
+                    // insurance policy against profile deletions
+                    existingUser.setSingleAttribute("subjectDN", dodCert.SUBJECT_DN);
+                    existingUser.setSingleAttribute("cacUID", dodCert.EDIPI.toString());
+                    existingUser.setSingleAttribute("pivID", dodCert.getPivId());
                     authenticationFlowContext.setUser(existingUser);
                 }
             } else {


### PR DESCRIPTION
To handle for users present and future that might lose their CAC attributes, I am adding setSingleAttribute for edipi, piv, and subjectdn to each login even for the CAC user. This is should add little to no overhead, and should the CAC values change, we would want to capture them anyway.